### PR TITLE
Chore/error middleware

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -5,6 +5,7 @@ import helmet from 'helmet'
 import { limiter } from './shared/middlewares/rate-limiter.middleware'
 import { ENDPOINTS } from '@shared/constants/endpoints'
 import { authRouter } from '@auth/routers/auth.router'
+import { errorMiddleware } from '@shared/middlewares/error.middleware'
 
 const app = express()
 
@@ -15,5 +16,7 @@ app.use(helmet())
 app.use(limiter)
 
 app.use(ENDPOINTS.AUTH, authRouter)
+
+app.use(errorMiddleware)
 
 export { app }

--- a/apps/api/src/shared/middlewares/error.middleware.ts
+++ b/apps/api/src/shared/middlewares/error.middleware.ts
@@ -1,0 +1,12 @@
+import { handler } from '@shared/utils/error.handler'
+import { NextFunction, Request, Response } from 'express'
+
+export const errorMiddleware = async (
+  err: Error,
+  req: Request,
+  res: Response,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _next: NextFunction
+): Promise<Response | void> => {
+  await handler.handleError(err, { source: 'http' }, req, res)
+}

--- a/apps/api/src/shared/utils/error.handler.ts
+++ b/apps/api/src/shared/utils/error.handler.ts
@@ -1,0 +1,104 @@
+import { Request, Response } from 'express'
+import { AppError } from './error'
+import { JsonWebTokenError } from 'jsonwebtoken'
+import { HTTP_CODES } from '@shared/constants/http.codes'
+import { EntityNotFoundError, QueryFailedError } from 'typeorm'
+
+export const ERROR_SOURCE = {
+  HTTP: 'http',
+  PROCESS: 'process'
+} as const
+
+export type ErrorSource = (typeof ERROR_SOURCE)[keyof typeof ERROR_SOURCE]
+
+export type ErrorContext = {
+  source: ErrorSource
+}
+
+export class ErrorHandler {
+  public async handleError(
+    e: unknown,
+    context: ErrorContext,
+    req?: Request,
+    res?: Response
+  ): Promise<void> {
+    const error = this.normalize(e)
+
+    if (context.source !== 'http') {
+      this.handleProcessError(error)
+      return
+    }
+
+    await this.sendHttpResponse(error, req!, res!)
+  }
+
+  private async sendHttpResponse(err: Error, _: Request, res: Response) {
+    if (err instanceof AppError) {
+      return res.status(Number(err.httpCode)).json({
+        status: err.httpCode,
+        message: err.message
+      })
+    }
+
+    if (err instanceof JsonWebTokenError) {
+      return res.status(HTTP_CODES.UNAUTHORIZED).json({
+        status: HTTP_CODES.UNAUTHORIZED,
+        message: err.message
+      })
+    }
+
+    return res.status(HTTP_CODES.INTERNAL).json({
+      status: HTTP_CODES.INTERNAL,
+      message: err.message ?? 'Internal Server Error.'
+    })
+  }
+
+  private isTrustedError(e: Error) {
+    return e instanceof AppError && e.isOperational
+  }
+
+  private handleProcessError(e: Error) {
+    const trusted = this.isTrustedError(e)
+    if (trusted) {
+      return
+    }
+    process.exit(1)
+  }
+
+  private normalize(e: unknown): Error {
+    let err: Error
+    if (e instanceof AppError) {
+      return e
+    } else if (e instanceof Error) {
+      err = e
+    } else {
+      err = new Error(typeof e === 'string' ? e : JSON.stringify(e))
+    }
+
+    if (err instanceof EntityNotFoundError) {
+      return new AppError({
+        httpCode: HTTP_CODES.NOT_FOUND,
+        message: 'Recurso no encontrado',
+        isOperational: true
+      })
+    }
+
+    if (err instanceof QueryFailedError) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const code = (err as any).driverError?.code
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const errno = (err as any).driverError?.errno
+      if (code === 'ER_DUP_ENTRY' || errno === 1062) {
+        return new AppError({
+          httpCode: HTTP_CODES.CONFLICT,
+          message: 'Registro duplicado',
+          isOperational: true
+        })
+      }
+    }
+
+    return err
+  }
+}
+
+export const handler = new ErrorHandler()

--- a/apps/api/src/shared/utils/error.handler.ts
+++ b/apps/api/src/shared/utils/error.handler.ts
@@ -78,8 +78,7 @@ export class ErrorHandler {
     if (err instanceof EntityNotFoundError) {
       return new AppError({
         httpCode: HTTP_CODES.NOT_FOUND,
-        message: 'Recurso no encontrado',
-        isOperational: true
+        message: 'Recurso no encontrado'
       })
     }
 
@@ -91,8 +90,7 @@ export class ErrorHandler {
       if (code === 'ER_DUP_ENTRY' || errno === 1062) {
         return new AppError({
           httpCode: HTTP_CODES.CONFLICT,
-          message: 'Registro duplicado',
-          isOperational: true
+          message: 'Registro duplicado'
         })
       }
     }

--- a/apps/api/src/shared/utils/error.ts
+++ b/apps/api/src/shared/utils/error.ts
@@ -1,0 +1,24 @@
+import { HttpCode } from '@shared/constants/http.codes'
+
+type ErrorParams = {
+  // code: Code
+  httpCode?: HttpCode
+  message: string
+  isOperational: boolean
+}
+
+export class AppError extends Error {
+  public readonly httpCode?: HttpCode
+  public readonly isOperational: boolean
+
+  constructor({ httpCode, message, isOperational = true }: ErrorParams) {
+    super(message)
+
+    Object.setPrototypeOf(this, new.target.prototype)
+
+    this.httpCode = httpCode
+    this.isOperational = isOperational
+
+    Error.captureStackTrace(this)
+  }
+}

--- a/apps/api/src/shared/utils/error.ts
+++ b/apps/api/src/shared/utils/error.ts
@@ -4,12 +4,12 @@ type ErrorParams = {
   // code: Code
   httpCode?: HttpCode
   message: string
-  isOperational: boolean
+  isOperational?: boolean
 }
 
 export class AppError extends Error {
   public readonly httpCode?: HttpCode
-  public readonly isOperational: boolean
+  public readonly isOperational: boolean = true
 
   constructor({ httpCode, message, isOperational = true }: ErrorParams) {
     super(message)

--- a/docs/flowcharts/error-flow.mmd
+++ b/docs/flowcharts/error-flow.mmd
@@ -1,0 +1,36 @@
+graph TD
+    subgraph Middleware
+        B[errorMiddleware];
+    end
+
+    subgraph "ErrorHandler Util"
+        C["ErrorHandler.handleError"]
+        D["Normalizar Error"]
+        E{"¿Es AppError?"}
+        G{"¿Es JsonWebTokenError?"}
+        I{"¿Es EntityNotFoundError?"}
+        K{"¿Es QueryFailedError con duplicado?"}
+        J["Crear AppError con 404 Not Found"]
+        L["Crear AppError con 409 Conflict"]
+    end
+
+    subgraph "HTTP Response"
+        F["Enviar respuesta HTTP con AppError.httpCode"]
+        H["Enviar respuesta HTTP con 401 Unauthorized"]
+        M["Enviar respuesta HTTP con 500 Internal Server Error"]
+    end
+
+    A["Error en la solicitud HTTP"] --> B
+    B --> C
+    C --> D
+    D --> E
+    E -- Sí --> F
+    E -- No --> G
+    G -- Sí --> H
+    G -- No --> I
+    I -- Sí --> J
+    J --> F
+    I -- No --> K
+    K -- Sí --> L
+    L --> F
+    K -- No --> M


### PR DESCRIPTION
```mermaid
graph TD
    subgraph Middleware
        B[errorMiddleware];
    end

    subgraph "ErrorHandler Util"
        C["ErrorHandler.handleError"]
        D["Normalizar Error"]
        E{"¿Es AppError?"}
        G{"¿Es JsonWebTokenError?"}
        I{"¿Es EntityNotFoundError?"}
        K{"¿Es QueryFailedError con duplicado?"}
        J["Crear AppError con 404 Not Found"]
        L["Crear AppError con 409 Conflict"]
    end

    subgraph "HTTP Response"
        F["Enviar respuesta HTTP con AppError.httpCode"]
        H["Enviar respuesta HTTP con 401 Unauthorized"]
        M["Enviar respuesta HTTP con 500 Internal Server Error"]
    end

    A["Error en la solicitud HTTP"] --> B
    B --> C
    C --> D
    D --> E
    E -- Sí --> F
    E -- No --> G
    G -- Sí --> H
    G -- No --> I
    I -- Sí --> J
    J --> F
    I -- No --> K
    K -- Sí --> L
    L --> F
    K -- No --> M
```