### PR TITLE
chore(client): endpoints, aliases, user &  auth contexts, avatar component

### DIFF
--- a/apps/client/src/modules/auth/context/auth.context.ts
+++ b/apps/client/src/modules/auth/context/auth.context.ts
@@ -1,13 +1,17 @@
 import { create } from 'zustand'
 
 interface AuthState {
-  access_token: string
+  access_token: string | null
   setAuth: (jwt: string) => void
+  clearAuth: () => void
 }
 
 export const useAuthStore = create<AuthState>()((set) => ({
-  access_token: '',
+  access_token: null,
   setAuth: (jwt: string) => {
     set(() => ({ access_token: jwt }))
+  },
+  clearAuth: () => {
+    set(() => ({ access_token: null }))
   }
 }))

--- a/apps/client/src/modules/user/context/user.context.ts
+++ b/apps/client/src/modules/user/context/user.context.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand'
+import { UserService } from '../services/user.service'
+
+type UserProfile = {
+  id: number
+  name: string
+  email: string
+  dni: string
+  state: boolean
+  role: 'lessor' | 'tenant'
+  photo: null | string
+}
+
+interface UserStore {
+  user: UserProfile | null
+  loading: boolean
+  error: string | null
+  recoverUser: () => Promise<void>
+}
+
+export const useUserStore = create<UserStore>((set) => ({
+  user: null,
+  loading: false,
+  error: null,
+  recoverUser: async () => {
+    set({ loading: true, error: null })
+    try {
+      const user = await UserService.getProfile()
+      set({ user, loading: false })
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        set({ user: null, loading: false, error: err.message })
+      } else {
+        set({ user: null, loading: false, error: 'Error inesperado' })
+      }
+    }
+  }
+}))

--- a/apps/client/src/modules/user/services/user.service.ts
+++ b/apps/client/src/modules/user/services/user.service.ts
@@ -1,0 +1,21 @@
+import { type UserResponseProfile } from '@/types'
+import { api } from '@shared/api/api'
+import { ENDPOINTS } from '@shared/api/endpoints'
+import { AxiosError } from 'axios'
+
+export class UserService {
+  static async getProfile() {
+    try {
+      const { data } = await api.get<UserResponseProfile>(ENDPOINTS.USER)
+
+      return data
+    } catch (error) {
+      if (error instanceof AxiosError) {
+        throw new Error(
+          error.response?.data?.message || 'Error al obtener el perfil'
+        )
+      }
+      throw new Error('Error desconocido al obtener el perfil')
+    }
+  }
+}

--- a/apps/client/src/shared/api/api.ts
+++ b/apps/client/src/shared/api/api.ts
@@ -1,8 +1,60 @@
-import axios from 'axios'
+import { useAuthStore } from '@auth/context/auth.context'
+import axios, { type AxiosRequestConfig } from 'axios'
+import { ENDPOINTS } from './endpoints'
 
 const api = axios.create({
   baseURL: '/api',
   withCredentials: true
 })
+
+const apiRefresh = axios.create({
+  baseURL: '/api',
+  withCredentials: true
+})
+
+api.interceptors.request.use((config) => {
+  const token = useAuthStore.getState().access_token
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`
+  }
+  return config
+})
+
+type RefreshResponse = {
+  access_token: string
+}
+
+export interface AxiosRequestConfigWithRetry extends AxiosRequestConfig {
+  _retry?: boolean
+}
+
+api.interceptors.response.use(
+  (response) => response,
+  async (e) => {
+    const originalRequest = e.config as AxiosRequestConfigWithRetry
+
+    if (e.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true
+
+      try {
+        const { data } = await apiRefresh.get<RefreshResponse>(
+          ENDPOINTS.REFRESH
+        )
+        useAuthStore.getState().setAuth(data.access_token)
+
+        console.log('Recovering token ' + data.access_token)
+        originalRequest.headers = {
+          ...originalRequest.headers,
+          Authorization: `Bearer ${useAuthStore.getState().access_token}`
+        }
+
+        console.log('Resending request')
+        return api(originalRequest)
+      } catch (e) {
+        return Promise.reject(e)
+      }
+    }
+  }
+)
 
 export { api }

--- a/apps/client/src/shared/api/endpoints.ts
+++ b/apps/client/src/shared/api/endpoints.ts
@@ -1,5 +1,7 @@
 export const ENDPOINTS = {
   TENANT: '/auth/tenant',
   LESSOR: '/auth/lessor',
-  LOGIN: '/auth/login'
+  LOGIN: '/auth/login',
+  REFRESH: '/auth/refresh',
+  USER: '/user'
 }

--- a/apps/client/src/shared/components/LinkAvatar.tsx
+++ b/apps/client/src/shared/components/LinkAvatar.tsx
@@ -1,0 +1,21 @@
+import type { HTMLAttributes, HTMLElementType } from 'react'
+import { Link } from 'react-router'
+
+export type AvatarProps = {
+  photo: string | null
+  className: HTMLAttributes<HTMLElementType>['className']
+}
+
+export function LinkAvatar({ photo, className }: AvatarProps) {
+  const placeholder = 'https://placehold.co/150x150'
+
+  return (
+    <Link to={'/profile'} className="avatar">
+      <div
+        className={`${className} hover:ring-primary ring-offset-base-100 hover:ring-2 ring-offset-2 transition-all duration-200 rounded-full`}
+      >
+        <img src={photo ?? placeholder} />
+      </div>
+    </Link>
+  )
+}

--- a/apps/client/src/types.d.ts
+++ b/apps/client/src/types.d.ts
@@ -1,0 +1,9 @@
+export type UserResponseProfile = {
+  id: number
+  name: string
+  email: string
+  dni: string
+  state: boolean
+  role: 'lessor' | 'tenant'
+  photo: null | string
+}

--- a/apps/client/tsconfig.app.json
+++ b/apps/client/tsconfig.app.json
@@ -28,6 +28,7 @@
       "@auth/*": ["./src/modules/auth/*"],
       "@lessor/*": ["./src/modules/lessor/*"],
       "@tenant/*": ["./src/modules/tenant/*"],
+      "@user/*": ["./src/modules/user/*"],
       "@modules/*": ["./src/modules/*"],
       "@/*": ["./src/*"]
     }

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       '@auth': '/src/modules/auth/',
       '@lessor': '/src/modules/lessor/',
       '@tenant': '/src/modules/tenant/',
+      '@user': '/src/modules/user/',
       '@modules': '/src/modules/',
       '@': '/src/'
     }


### PR DESCRIPTION
## Descripción del PR

Este PR introduce varias mejoras y refactorizaciones relacionadas con la gestión de usuarios y autenticación, incluyendo contexto, servicios, interceptores de API y componentes UI. Los cambios principales son:

### Contexto y estado de usuario

* Se agregó la función `clearAuth` al contexto de Zustand, que permite limpiar los tokens de acceso (`access_token = null`).
* Se creó `user.context.ts` usando Zustand, que maneja:

  * `user`: información del usuario.
  * `loading`: estado de carga.
  * `error`: errores al recuperar información.
  * `recoverUser()`: método para obtener la información del usuario desde la API.

### Servicios

* `user.service.ts` implementa la función para obtener la información del usuario desde el endpoint `/user`.
* Se definió el tipado `UserResponseProfile` para las respuestas de perfil.

### Interceptores de Axios

* Se creó la instancia `api` con `axios.create()`.
* Se añadieron interceptores:

  * **Request**: agrega el `access_token` al header `Authorization`.
  * **Response**: ante un error `401`, se envía automáticamente una petición a `/auth/refresh`, se actualiza el token en el contexto y se reintenta la petición original.

### Endpoints

* Se añadieron dos nuevos endpoints en `endpoints.ts`:

  * `/auth/refresh` → para refrescar tokens.
  * `/user` → para obtener información del usuario.

### Componentes UI

* Se creó `LinkAvatar` que recibe:

  * `foto`: string | null.
  * `className`: concatenado con las clases del elemento.

### Configuración y alias

* Se agregaron alias en `tsconfig.app.json` y `vite.config.ts` para simplificar imports.

---

### 🔹 Resumen

* Mejoras en la **gestión de autenticación** y tokens.
* Implementación de **Zustand para estado de usuario**.
* Manejo de **interceptores de Axios** para refresh de tokens.
* Nuevo **componente UI reutilizable** (`LinkAvatar`).
* Mejoras en **tipado y configuración de alias**.


