### PR TITLE
fix(client): ui password changing section in UserProfile page

### DIFF
--- a/apps/client/src/modules/user/components/DangerZone.tsx
+++ b/apps/client/src/modules/user/components/DangerZone.tsx
@@ -4,7 +4,7 @@ export function DangerZone() {
   const { deactiveUser } = useUserStore()
 
   return (
-    <section className="flex flex-col gap-3 mt-8">
+    <section className="flex flex-col gap-3">
       <p className="text-sm text-base-content/70">
         Desactivar tu cuenta eliminará el acceso de inmediato.
       </p>

--- a/apps/client/src/modules/user/components/PasswordSection.tsx
+++ b/apps/client/src/modules/user/components/PasswordSection.tsx
@@ -22,6 +22,9 @@ export function PasswordSection() {
           name="newPassword"
           placeholder="Ingresa tu nueva contraseña"
           required={false}
+          minLength={8} // Validación explícita
+          pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" // Validación explícita
+          title="Debe tener mínimo 8 caracteres e incluir número, letra minúscula y letra mayúscula"
         />
         <span className="text-xs text-base-content/60">
           Este campo debe estar vacío si no deseas actualizarla.

--- a/apps/client/src/modules/user/components/ProfileForm.tsx
+++ b/apps/client/src/modules/user/components/ProfileForm.tsx
@@ -10,8 +10,13 @@ export function ProfileForm({ name, email, dni, role, photo }: UserProfile) {
     event.preventDefault()
   }
 
+  const handlePasswordChange = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+  }
+
   return (
     <>
+      {/* Sección para editar el perfil */}
       <form
         className="lg:grid lg:grid-cols-2 lg:grid-rows-[auto_auto] gap-4 flex flex-col w-full"
         onSubmit={handleSubmit}
@@ -32,8 +37,6 @@ export function ProfileForm({ name, email, dni, role, photo }: UserProfile) {
             placeholder="juan.perez@email.com"
             defaultValue={email}
           />
-
-          <PasswordSection />
 
           <Input
             labelContent="Documento de identificación"
@@ -62,6 +65,22 @@ export function ProfileForm({ name, email, dni, role, photo }: UserProfile) {
         </div>
       </form>
 
+      {/* Sección para cambiar la contraseña */}
+      <h2 className="mt-5 text-2xl font-semibold">Cambiar contraseña</h2>
+      <form
+        className="lg:grid lg:grid-cols-2 lg:grid-rows-[auto_auto] gap-4 flex flex-col w-full"
+        onSubmit={handlePasswordChange}
+      >
+        <div className="flex flex-col gap-5 mt-5 lg:mt-0 col-span-1">
+          <PasswordSection />
+          <button type="submit" className="btn btn-outline btn-primary w-fit">
+            Guardar cambios
+          </button>
+        </div>
+      </form>
+
+      {/* Sección para desactivar la cuenta */}
+      <h2 className="text-2xl font-semibold">Desactivar cuenta</h2>
       <DangerZone />
     </>
   )


### PR DESCRIPTION
# Rediseño técnico de la pagina UserProfile
Se separó dentro del componente ProfileForm, dos elementos form, uno que contiene la edición del perfil y otro que contiene exclusivamente el cambio de la contraseña del usuario.
<img width="935" height="874" alt="image" src="https://github.com/user-attachments/assets/a3edd7c9-25c1-4ea0-b2ba-6c210eebcbaa" />
<img width="1023" height="881" alt="image" src="https://github.com/user-attachments/assets/7c9a3d99-3f7a-4285-a4d3-24998889c79b" />
## Minidetalles corregidos
Se corrigió que el botón de "Mostrar contraseña" quitaba la validación al alternar a un input de tipo texto para que se muestre al usuario, antes al ser mostrada el input aceptaba cualquier contraseña.
### Ejemplo cumpliendo restricciones
<img width="671" height="345" alt="image" src="https://github.com/user-attachments/assets/6c5e7ad0-e059-49ce-87b3-4b9902bdf95b" />

### Ejemplo incumpliendo una restricción (mínimo una mayúscula)
<img width="733" height="431" alt="image" src="https://github.com/user-attachments/assets/d32b6ce7-1952-4b48-bbce-487c46579385" />

