### PR TITLE
feat: implementa el endpoint para obtener distritos

### DIFF
--- a/apps/api/src/modules/locations/controllers/district.controller.ts
+++ b/apps/api/src/modules/locations/controllers/district.controller.ts
@@ -1,0 +1,43 @@
+import { Request, Response } from 'express'
+import { DistrictService } from '@locations/services/district.service'
+
+// Se crea una instancia del servicio para que el controlador pueda usarla.
+const districtService = new DistrictService()
+
+/**
+ * @class DistrictController
+ * @description Maneja las peticiones HTTP entrantes (requests) y envía las respuestas (responses)
+ * para el recurso de distritos.
+ */
+export class DistrictController {
+  /**
+   * @method getAll
+   * @description Maneja la petición GET para obtener todos los distritos.
+   * @param {Request} req - El objeto de la solicitud Express.
+   * @param {Response} res - El objeto de la respuesta Express.
+   * @returns {Promise<Response>} Una promesa que resuelve a un objeto de respuesta Express.
+   */
+  async getAll(req: Request, res: Response): Promise<Response> {
+    try {
+      // Llama al servicio para obtener la lista de todos los distritos.
+      const districts = await districtService.getAll()
+
+      // Comprueba si la respuesta del servicio está vacía o es nula.
+      if (!districts || districts.length === 0) {
+        // Si no se encuentran distritos, devuelve un código de estado 404 (Not Found).
+        return res.status(404).json({ message: 'No se encontraron distritos' })
+      }
+
+      // Si todo sale bien, devuelve un código de estado 200 (OK) y la lista de distritos.
+      return res.status(200).json(districts)
+    } catch (error: unknown) {
+      // Si ocurre cualquier error en el servicio o el repositorio, se captura aquí.
+      // Devuelve un código de estado 500 (Internal Server Error) para indicar un fallo.
+      return res.status(500).json({
+        message: 'Error al obtener los distritos',
+        // Incluye el mensaje de error para facilitar la depuración.
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
+  }
+}

--- a/apps/api/src/modules/locations/repositories/district.repository.ts
+++ b/apps/api/src/modules/locations/repositories/district.repository.ts
@@ -1,0 +1,29 @@
+import { Repository } from 'typeorm'
+import { District } from '../entities/district.entity'
+import { AppDataSource } from '@shared/database/data-source'
+
+/**
+ * @class DistrictRepository
+ * @description Esta clase es responsable de la comunicación directa con la base de datos
+ * para todas las operaciones relacionadas con la entidad `District`.
+ */
+export class DistrictRepository {
+  // Declara una propiedad privada para almacenar el repositorio de TypeORM.
+  private Districtrepository: Repository<District>
+
+  constructor() {
+    // Inicializa el repositorio utilizando la conexión a la base de datos (AppDataSource)
+    // y especificando que es para la entidad `District`.
+    this.Districtrepository = AppDataSource.getRepository(District)
+  }
+
+  /**
+   * @method findAll
+   * @description Busca y devuelve todos los registros de distritos en la base de datos.
+   * @returns {Promise<District[]>} Una promesa que resuelve a un arreglo de entidades `District`.
+   */
+  async findAll(): Promise<District[]> {
+    // Utiliza el método `find()` de TypeORM para ejecutar un `SELECT * FROM ...` en la tabla de distritos.
+    return await this.Districtrepository.find()
+  }
+}

--- a/apps/api/src/modules/locations/routers/district.router.ts
+++ b/apps/api/src/modules/locations/routers/district.router.ts
@@ -1,0 +1,8 @@
+import express from 'express'
+import { DistrictController } from '@locations/controllers/district.controller'
+
+const districtRouter = express.Router()
+
+districtRouter.get('/', new DistrictController().getAll)
+
+export default districtRouter

--- a/apps/api/src/modules/locations/services/district.service.ts
+++ b/apps/api/src/modules/locations/services/district.service.ts
@@ -1,0 +1,27 @@
+import { DistrictRepository } from '../repositories/district.repository'
+import { District } from '../entities/district.entity'
+
+/**
+ * @class DistrictService
+ * @description Contiene la lógica de negocio para los distritos. Actúa como
+ * intermediario entre el controlador y el repositorio.
+ */
+export class DistrictService {
+  // Declara una propiedad privada para mantener una instancia del repositorio.
+  private districtRepository: DistrictRepository
+
+  constructor() {
+    // Crea una nueva instancia del `DistrictRepository` para poder acceder a la base de datos.
+    this.districtRepository = new DistrictRepository()
+  }
+
+  /**
+   * @method getAll
+   * @description Obtiene todos los distritos registrados llamando a la capa del repositorio.
+   * @returns {Promise<District[]>} Una promesa que resuelve a una lista de distritos.
+   */
+  async getAll(): Promise<District[]> {
+    // Llama al método `findAll()` del repositorio para obtener los datos.
+    return await this.districtRepository.findAll()
+  }
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -12,6 +12,7 @@ import { userRouter } from '@users/user.router'
 import { join } from 'node:path'
 import { mkdirSync } from 'node:fs'
 import { FILES_ROUTE } from '@shared/constants/files.route'
+import districtRouter from '@locations/routers/district.router'
 
 const app = express()
 const uploadDir = join(process.cwd(), FILES_ROUTE)
@@ -26,6 +27,8 @@ app.use(limiter)
 app.use('/api/docs', swaggerUI.serve, swaggerUI.setup(swaggerDocs))
 app.use(ENDPOINTS.AUTH, authRouter)
 app.use(ENDPOINTS.USER, userRouter)
+//Ruta para mostrar todos los distritos
+app.use('/api/districts', districtRouter)
 
 app.use(errorMiddleware)
 


### PR DESCRIPTION
Este PR introduce el flujo completo (Controlador, Servicio, Repositorio) para consultar la lista de distritos desde la base de datos a través del endpoint GET /api/districts.

Cambios Realizados
Se creó DistrictController para manejar las peticiones HTTP.

Se implementó DistrictService con la lógica de negocio.

Se añadió DistrictRepository para el acceso a datos con TypeORM.

¿Cómo Probarlo?
Levantar el servidor.

Realizar una petición GET a http://localhost:3000/api/districts.

Verificar que la respuesta sea un JSON con la lista de distritos y un estado 200.